### PR TITLE
Communicate WiFi connections to ATmega

### DIFF
--- a/mcu/src/Main.c
+++ b/mcu/src/Main.c
@@ -19,6 +19,8 @@ void check_frame (circular_buf * );
 int main (void) {
     // Initialize buffers first as UART needs them
     init_buffer(&buff_wifi_rx, BUFFER_LENGTH_BYTES);
+    init_buffer(&buff_trans_rx, BUFFER_LENGTH_BYTES);
+    init_device_table();
     UART_WiFi_init(UBRR_WIFI);
     DDR(PORT_STATUS_LED) |= (1<<PIN_STATUS_LED);
     DDR(PORT_TEST_LED) |= (1<<PIN_TEST_LED);
@@ -27,6 +29,7 @@ int main (void) {
         PORT(PORT_STATUS_LED) ^= (1<<PIN_STATUS_LED);
 
         read_frame(&buff_wifi_rx);
+        read_frame(&buff_trans_rx);
         
     }
 }

--- a/mcu/src/buffer.c
+++ b/mcu/src/buffer.c
@@ -1,6 +1,7 @@
 #include "buffer.h"
 
 circular_buf buff_wifi_rx;
+circular_buf buff_trans_rx;
 
 /** 
  * First check the head and tail of the buffer and make sure they do not match to avoid

--- a/mcu/src/buffer.h
+++ b/mcu/src/buffer.h
@@ -2,7 +2,7 @@
 #define BUFFER_H
 
 #define FRAME_LENGTH_MAX 256
-#define BUFFER_LENGTH_FRAMES 4 // number of frames
+#define BUFFER_LENGTH_FRAMES 2 // number of frames
 #define BUFFER_LENGTH_BYTES (BUFFER_LENGTH_FRAMES * FRAME_LENGTH_MAX)
 
 #include <stdint.h>
@@ -24,6 +24,7 @@ typedef struct circular_buf {
 } circular_buf;
 
 extern circular_buf buff_wifi_rx;
+extern circular_buf buff_trans_rx;
 
 /** 
  * Read a byte from a buffer as referenced by the head pointer. The byte in the buffer is then cleared before the head pointer is incremented.

--- a/mcu/src/comms.c
+++ b/mcu/src/comms.c
@@ -16,6 +16,18 @@ ISR(WIFI_RX_vect) {
     }
 }
 
+ISR(TRANS_RX_vect) {
+    // when interrupt is triggered then write UDR into buffer so we do not lose information
+    buff_trans_rx.buff[buff_trans_rx.tail++] = UDR1;
+    buff_trans_rx.free--;
+
+    PORT(PORT_TEST_LED) ^= (1<<PIN_TEST_LED);
+
+    if (buff_trans_rx.tail >= buff_trans_rx.size) {
+        buff_trans_rx.tail = 0;
+    }
+}
+
 /** 
  * Initializes a given buffer for use. This function sets the baud rate, enables transmission and reception,
  * and enables a receive interrupt for UART.
@@ -30,6 +42,12 @@ void UART_WiFi_init (unsigned int ubrr) {
     UCSRB_WIFI = (1<<RXEN_WIFI)|(1<<TXEN_WIFI); // Enable receiving and transmission on UART
     UCSRB_WIFI |= (1<<RXCIE_WIFI); // enable receive interrupt for circular buffer
 
+    // Enable WiFi UART
+    UBRRH_TRANS = (unsigned char)(ubrr>>8); // Set high bits of UBRR for baud rate
+    UBRRL_TRANS = (unsigned char)(ubrr); // Set low bits of UBRR for baud
+    UCSRB_TRANS = (1<<RXEN_TRANS)|(1<<TXEN_TRANS); // Enable receiving and transmission on UART
+    UCSRB_TRANS |= (1<<RXCIE_TRANS); // enable receive interrupt for circular buffer
+
     sei(); //enable interrupts
 }
 
@@ -40,5 +58,10 @@ void UART_WiFi_init (unsigned int ubrr) {
 void UART_WiFi_TX (uint8_t byte) {
     while(!( UCSRA_WIFI & (1<<UDRE_WIFI))); // Wait for TX to finish
     UDR_WIFI = byte; // Write for TX
+}
+
+void UART_TRANS_TX (uint8_t byte) {
+    while(!( UCSRA_TRANS & (1<<UDRE_TRANS))); // Wait for TX to finish
+    UDR_TRANS = byte; // Write for TX
 }
 

--- a/mcu/src/comms.h
+++ b/mcu/src/comms.h
@@ -48,6 +48,7 @@ void UART_WiFi_init(unsigned int);
  * @param byte Byte of data to send to WiFi module
  */
 void UART_WiFi_TX (uint8_t);
+void UART_TRANS_TX (uint8_t byte);
 
 
 

--- a/mcu/src/routing.c
+++ b/mcu/src/routing.c
@@ -2,6 +2,8 @@
 #include <stdint.h>
 #include "comms.h"
 
+static wifi_device connected_devices[ESP_MAX_CONN];
+
 void read_frame (circular_buf *buffer_ptr) {
     if(buffer_ptr->free < buffer_ptr->size) {
         uint8_t data_len;
@@ -12,6 +14,7 @@ void read_frame (circular_buf *buffer_ptr) {
                     route_message(buffer_ptr);
                     break;
                 case 0x02: // New device (dis)connected
+                    handle_connection(buffer_ptr);
                     break;
                 case 0x03: // NUB topology adjustment
                     break;
@@ -28,7 +31,105 @@ void route_message(circular_buf *buffer_ptr) {
     mess_len = (read_buffer(buffer_ptr) << 8); // Read in high bits
     mess_len |= read_buffer(buffer_ptr); // Read in low bits
 
-    for (size_t i = 0; i < mess_len; i++) { // loop through length of data
-        UART_WiFi_TX(read_buffer(buffer_ptr)); // Write to TX
+    uint8_t sourceMAC[6];
+    read_MAC(buffer_ptr, sourceMAC);
+    int connected = find_MAC(sourceMAC);
+
+    if (connected < 0) {
+        UART_TRANS_TX(0x02);
+        UART_TRANS_TX(0x00);
+        UART_TRANS_TX(0x01);
+        UART_TRANS_TX( (uint8_t)(mess_len >> 8));
+        UART_TRANS_TX( (uint8_t)(mess_len & 0x00FF));
+        for (size_t i = 0; i < MAC_LENGTH; i++) {
+            UART_TRANS_TX(sourceMAC[i]);
+        }
+        for (size_t i = 0; i < mess_len - MAC_LENGTH; i++) { // loop through length of data
+            UART_TRANS_TX(read_buffer(buffer_ptr)); // Write to TX
+        }
+
+    } else {
+        UART_WiFi_TX(0x02);
+        UART_WiFi_TX(0x00);
+        UART_WiFi_TX(0x01);
+        UART_WiFi_TX( (uint8_t)(mess_len >> 8));
+        UART_WiFi_TX( (uint8_t)(mess_len & 0x00FF));
+        for (size_t i = 0; i < MAC_LENGTH; i++) {
+            UART_WiFi_TX(sourceMAC[i]);
+        }
+        for (size_t i = 0; i < mess_len - MAC_LENGTH; i++) { // loop through length of data
+            UART_WiFi_TX(read_buffer(buffer_ptr)); // Write to TX
+        }
     }
+
+    
+}
+
+void handle_connection (circular_buf *buffer_ptr) {
+    wifi_device mod_device;
+    mod_device.mac = malloc(MAC_LENGTH * sizeof(uint8_t));
+    switch (read_buffer(buffer_ptr)) {
+    case 0x01: // Connected
+        read_MAC(buffer_ptr, mod_device.mac);
+
+        for (size_t dev_index = 0; dev_index < ESP_MAX_CONN; dev_index++) {
+            if (connected_devices[dev_index].state == Disconnected) {
+                copy_MAC(mod_device.mac,connected_devices[dev_index].mac);
+                connected_devices[dev_index].state = Connected;
+                break;
+            }
+        }
+        break;
+    
+    case 0x02: // Disconnected
+        for (size_t dev_index = 0; dev_index < ESP_MAX_CONN; dev_index++) {
+            if (compare_MAC( connected_devices[dev_index].mac, mod_device.mac )) {
+                connected_devices[dev_index].state = Disconnected;
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    free(mod_device.mac);
+}
+
+void init_device_table(void) {
+    for (size_t i = 0; i < ESP_MAX_CONN; i++) {
+        connected_devices[i].mac = malloc(MAC_LENGTH * sizeof(uint8_t));
+        connected_devices[i].state = Disconnected;
+    }
+}
+
+bool compare_MAC (uint8_t *mac1, uint8_t *mac2) {
+    bool match = true;
+    for (size_t mac_index = 0; mac_index < MAC_LENGTH; mac_index++) {
+        match = mac1[mac_index] == mac2[mac_index];
+        if (!match) {break;}
+    }
+    return match;
+}
+
+void copy_MAC (uint8_t *mac_in, uint8_t *mac_out) {
+    for (size_t mac_index = 0; mac_index < MAC_LENGTH; mac_index++) {
+        mac_out[mac_index] = mac_in[mac_index];
+    }
+}
+
+void read_MAC (circular_buf *buffer_ptr, uint8_t *mac_out) {
+    for (size_t mac_index = 0; mac_index < MAC_LENGTH; mac_index++) {
+        mac_out[mac_index] = read_buffer(buffer_ptr);
+    }
+}
+
+int find_MAC (uint8_t *mac) {
+    int result = -1;
+    for (size_t i = 0; i < ESP_MAX_CONN; i++) {
+        if ( compare_MAC(mac, connected_devices[i].mac) ) {
+            return i;
+        }
+    }
+    return result;
 }

--- a/mcu/src/routing.h
+++ b/mcu/src/routing.h
@@ -3,8 +3,33 @@
 
 #include "buffer.h"
 
+#define ESP_MAX_CONN 4
+#define MAC_LENGTH 6
+
+typedef enum connection_state {
+    Connected, 
+    Disconnected
+} connection_state;
+
+typedef struct wifi_device {
+    uint8_t *mac;
+    connection_state state;
+} wifi_device;
+
 void read_frame (circular_buf * );
 
 void route_message(circular_buf * );
+
+void handle_connection (circular_buf *buffer_ptr);
+
+void init_device_table(void);
+
+bool compare_MAC (uint8_t *mac1, uint8_t *mac2);
+
+void copy_MAC (uint8_t *mac_in, uint8_t *mac_out);
+
+void read_MAC (circular_buf *buffer_ptr, uint8_t *mac_out);
+
+int find_MAC (uint8_t *mac);
 
 #endif

--- a/wifi/main/routing.h
+++ b/wifi/main/routing.h
@@ -77,6 +77,8 @@ void copy_MAC (uint8_t *mac_in, uint8_t *mac_out);
  */
 void handle_connection_frame (message_frame *rx_frame);
 
+void connection_frame_mcu (wifi_device *mod_device);
+
 /**
  * Get socket address information from MAC address
  * 


### PR DESCRIPTION
This merge will allow the ESP to communicate to the ATmega when a WiFi device connects or disconnects. This merge also fixes the ESP overwriting the whole connection table with a single device.