### PR TITLE
Set up threads for receiving and sending on the app

### DIFF
--- a/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
+++ b/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
@@ -101,7 +101,7 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
 
                 System.arraycopy(sendermacAddressBytes, 0, connection_status, 2, sendermacAddressBytes.length);
                 DatagramPacket connection_packet = new DatagramPacket(connection_status, connection_status.length, serverAddr, 3333);
-                
+
                 try {
                     socket.send(connection_packet);
                 }
@@ -204,7 +204,7 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
 
                     String s = textResponse.getText().toString();
                     if (received.trim().length() != 0)
-                        textResponse.setText(s + "\n    Server Reply : " + received);
+                        textResponse.setText("Server Reply : " + received.substring(13) + "\n" + s);
                 }
                 catch (IOException e) {
                     e.printStackTrace();

--- a/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
+++ b/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
@@ -46,7 +46,7 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
     public static String networkPass = "capstone1234";
     public DatagramSocket socket;
     public InetAddress serverAddr;
-    public Boolean ESPNotified = false;
+    public Boolean ESPNotified;
 
 
 
@@ -62,6 +62,8 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
         Recipient = (EditText) findViewById(R.id.number);
         disconnect_button = (Button) findViewById(R.id.disconnect_button);
         SenderMac = (EditText) findViewById(R.id.sender_mac);
+
+        ESPNotified = false;
 
         socket = null;
         try {
@@ -199,12 +201,12 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
 
                     DatagramPacket packet;
 
-                    if (ESPNotified == false) {
+                    if (!ESPNotified) {
                         byte[] connection_status = new byte[8];
                         connection_status[0] = (byte)0x02;
                         connection_status[1] = (byte)0x01;
 
-                        System.arraycopy(sendermacAddressBytes, 0, connection_status, 2, recipientmacAddressBytes.length);
+                        System.arraycopy(sendermacAddressBytes, 0, connection_status, 2, sendermacAddressBytes.length);
                         DatagramPacket connection_packet = new DatagramPacket(connection_status, connection_status.length, serverAddr, 3333);
 
                         socket.send(connection_packet);
@@ -212,7 +214,8 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
                     }
 
                     // set the first byte
-                    byte[] message_array = new byte[1024];
+                    //byte[] message_array = new byte[1024];
+                    byte[] message_array = new byte[message.getBytes().length + 2 + 12];
                     message_array[0] = (byte)0x01;
 
                     // set the second byte for connect/disconnect activity

--- a/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
+++ b/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
@@ -11,6 +11,7 @@ import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.StrictMode;
+import android.provider.ContactsContract;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
@@ -45,6 +46,7 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
     public static String networkPass = "capstone1234";
     public DatagramSocket socket;
     public InetAddress serverAddr;
+    public Boolean ESPNotified = false;
 
 
 
@@ -196,6 +198,17 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
                 try {
 
                     DatagramPacket packet;
+
+                    if (ESPNotified == false) {
+                        byte[] connection_status = new byte[8];
+                        connection_status[0] = (byte)0x02;
+                        connection_status[1] = (byte)0x01;
+
+                        System.arraycopy(sendermacAddressBytes, 0, connection_status, 2, recipientmacAddressBytes.length);
+                        DatagramPacket connection_packet = new DatagramPacket(connection_status, connection_status.length, serverAddr, 3333);
+
+                        socket.send(connection_packet);
+                    }
 
                     // set the first byte
                     byte[] message_array = new byte[1024];

--- a/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
+++ b/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
@@ -208,6 +208,7 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
                         DatagramPacket connection_packet = new DatagramPacket(connection_status, connection_status.length, serverAddr, 3333);
 
                         socket.send(connection_packet);
+                        ESPNotified = true;
                     }
 
                     // set the first byte

--- a/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
+++ b/android_app/app/src/main/java/com/example/nubapplication/TextingActivity.java
@@ -200,11 +200,17 @@ public class TextingActivity extends AppCompatActivity implements View.OnClickLi
 
                 try {
                     socket.receive(packet);
+                    byte[] received_bytes = new byte[packet.getLength()];
+                    received_bytes = packet.getData();
                     String received = new String(packet.getData(), 0, packet.getLength());
+
+                    String senderString = String.format("%x:%x:%x:%x:%x:%x", received_bytes[7],
+                            received_bytes[8], received_bytes[9], received_bytes[10],
+                            received_bytes[11], received_bytes[12]);
 
                     String s = textResponse.getText().toString();
                     if (received.trim().length() != 0)
-                        textResponse.setText("Server Reply : " + received.substring(13) + "\n" + s);
+                        textResponse.setText(senderString +  " : " + received.substring(13) + "\n" + s);
                 }
                 catch (IOException e) {
                     e.printStackTrace();


### PR DESCRIPTION
This merge fixes up the app for demo time.

- Receives message packets on own thread with loop
- Pretties up the received messages window, with new messages appearing at the **top** and showing the MAC address of the sender
- Notifies the ESP on connect/disconnect

Still to-do after this merge:
- Add error handling when the text fields are empty